### PR TITLE
docs(README): reduced need for horizontal scroll of example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,30 +24,32 @@ steps:
     uses: actions/setup-java@v4
     with:
       distribution: 'temurin'
-      java-version: '17'
+      java-version: 17
   
   # Install the Firebase Emulator Suite
   - name: Start Firebase Emulator Suite
     uses: firebase-emulator-action@v1
     with:
-      # The version of the Firebase CLI to install, (`npm install -g firebase-tools@${firebase-tools-version}`)
+      # Firebase CLI version to install, (`npm install -g firebase-tools@${firebase-tools-version}`)
       firebase-tools-version: 'latest'
 
-      # A comma separated list of emulators to start.
+      # Comma separated list of emulators to start. This example is the default:
       emulators: 'auth,firestore,functions,storage,database'
 
-      # The project ID to use, defaults to 'test-project'.
+      # Project ID to use, defaults to 'test-project'.
       project-id: 'test-project'
 
-      # The maximum number of retries to attempt before failing the action, defaults to 3.
+      # Maximum attempted retries to before action fails, defaults to 3.
       max-retries: '3'
 
-      # The maximum number of checks to perform before failing the retry, defaults to 60.
+      # Maximum checks to perform before retry fails, defaults to 60.
       max-checks: '60'
 
-      # The time to wait between checks in seconds, defaults to 1.
+      # Seconds to wait between checks, defaults to 1.
       wait-time: '1'
 
-      # The port to check for the emulators, defaults to 9099 (Cloud Firestore). Change this if you are using specific emulators. See https://firebase.google.com/docs/emulator-suite/install_and_configure#port_configuration.
+      # Port to check for emulator startup status, defaults to 9099 (Cloud Firestore).
+      # Change this if you are using specific emulators or non-standard ports.
+      # See https://firebase.google.com/docs/emulator-suite/install_and_configure#port_configuration.
       check-port: '9099'
 ```


### PR DESCRIPTION

When checking the README I noticed that there was a horizontal scroll for not much benefit

- added manual line break where needed, re-worded where possible