### PR TITLE
fix(bug): use relative path for start-firebase-emulator script references

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -43,4 +43,11 @@ runs:
     - name: Start Firebase Emulator
       shell: bash
       run: |
-       chmod +x ./start-firebase-emulator.sh && ./start-firebase-emulator.sh ${{ inputs.emulators }} ${{ inputs.project-id }} ${{ inputs.max-retries }} ${{ inputs.max-checks }} ${{ inputs.wait-time }} ${{ inputs.check-port }}
+        chmod +x ${{ github.action_path }}/start-firebase-emulator.sh
+        ${{ github.action_path }}/start-firebase-emulator.sh \
+          ${{ inputs.emulators }} \
+          ${{ inputs.project-id }} \
+          ${{ inputs.max-retries }} \
+          ${{ inputs.max-checks }} \
+          ${{ inputs.wait-time }} \
+          ${{ inputs.check-port }}


### PR DESCRIPTION
This PR fixes #4 

This solution has been tested via;
Repository: https://github.com/HassanBahati/demo-script-action
File: [custom.yml](https://github.com/HassanBahati/demo-script-action/blob/main/.github/workflows/custom.yml)

Previously, the action would as well fail with a similar error 
<img width="1042" alt="image" src="https://github.com/user-attachments/assets/f7bba5bd-2ca9-4723-9dda-1cfbeb4889ce">


On updating to use relative paths, the action executed successfully
<img width="1042" alt="image" src="https://github.com/user-attachments/assets/71104dc0-210a-4d86-a5c3-a48959e269f8">

