### PR TITLE
feat: enable shorthand vX tags inherited from latest version

### DIFF
--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -1,0 +1,33 @@
+name: Release and Tag Management
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-major-version-tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get major version
+        id: get_version
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          MAJOR_VERSION=v${VERSION%%.*}
+          echo "major_version=${MAJOR_VERSION}" >> $GITHUB_OUTPUT
+          echo "full_version=v${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Update major version tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -fa ${{ steps.get_version.outputs.major_version }} -m "Update major version tag to ${{ steps.get_version.outputs.full_version }}"
+          git push origin ${{ steps.get_version.outputs.major_version }} --force
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Currently to use the action you need to define the full version version eg `v1.0.0` resulting into `invertase/firebase-emulator-action@v1.0.0`. 

This PR enables usage of `vX` where X is any major release tag. Resulting into, for example; `invertase/firebase-emulator-action@v1`

I have tested out this approach via [custom-short-hand-tag.yaml](https://github.com/HassanBahati/demo-script-action/blob/main/.github/workflows/custom-short-hand-tag.yaml) for [HassanBahati/demo-script-action@v1](https://github.com/HassanBahati/demo-script-action)
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/beee4b1d-43fa-41ca-a10e-894f77e79172">
